### PR TITLE
Background filter set by number instead of option

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/BackgroundFilter.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/BackgroundFilter.lua
@@ -4,7 +4,7 @@ local mods = SL[pn].ActiveModifiers
 local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
 
 -- if no BackgroundFilter is necessary, it's safe to bail now
-if mods.BackgroundFilter == "Off" then return end
+if mods.BackgroundFilter == 0 then return end
 
 local FilterAlpha = {
 	Dark = 0.5,
@@ -16,7 +16,7 @@ return Def.Quad{
 	InitCommand=function(self)
 		self:xy(GetNotefieldX(player), _screen.cy )
 			:diffuse(Color.Black)
-			:diffusealpha( FilterAlpha[mods.BackgroundFilter] or 0 )
+			:diffusealpha( mods.BackgroundFilter / 100 )
 			:zoomto( GetNotefieldWidth() + 80, _screen.h )
 			:fadeleft(0.1):faderight(0.1)
 		if NoteFieldIsCentered and SL[pn].ActiveModifiers.DataVisualizations ~= "None" then

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DarkBackground.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DarkBackground.lua
@@ -11,7 +11,7 @@ local FilterAlpha = {
 
 return Def.Quad{
 	InitCommand=function(self)
-		self:diffuse(0, 0, 0, 0):setsize(width+100, _screen.h):y(-header_height):diffusealpha( FilterAlpha[mods.BackgroundFilter] or 0 )
+		self:diffuse(0, 0, 0, 0):setsize(width+100, _screen.h):y(-header_height):diffusealpha( mods.BackgroundFilter / 100 )
 		if NoteFieldIsCentered then
 			self:setsize(width, _screen.h)
 		else

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -248,7 +248,13 @@ local Overrides = {
 	},
 	-------------------------------------------------------------------------
 	BackgroundFilter = {
-		Values = { 'Off','Dark','Darker','Darkest' },
+		Choices = function()
+			local first = 0
+			local last = 100
+			local step = 1
+			
+			return range(first,last,step)
+		end
 	},
 	-------------------------------------------------------------------------
 	Mini = {

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -20,7 +20,7 @@ local permitted_profile_settings = {
 	JudgmentGraphic  = "string",
 	ComboFont        = "string",
 	HoldJudgment     = "string",
-	BackgroundFilter = "string",
+	BackgroundFilter = "number",
 
 	----------------------------------
 	-- "Advanced Modifiers"

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -11,7 +11,7 @@ local PlayerDefaults = {
 				HoldJudgment = "Love 1x2 (doubleres).png",
 				NoteSkin = nil,
 				Mini = "0%",
-				BackgroundFilter = "Off",
+				BackgroundFilter = 0,
 				VisualDelay = "0ms",
 				NotefieldShift = 0,
 


### PR DESCRIPTION
Allow background filter to be set by percentage number instead of just three options.

For reference, the old options were:
Dark = 50%
Darker = 75%
Darkest = 95%